### PR TITLE
fix(_base.scss): remove overflow setting on <html>

### DIFF
--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -33,7 +33,6 @@ html {
 * Overall page layout.
 */
 
-html,
 body {
   overflow-x: hidden;
 }


### PR DESCRIPTION
This keeps leading to issues with plugins like body scroll lock and should not be needed on the html element anyways since it's already set on the body.