### PR TITLE
feat(customPostTypes/example): add revisions to 'supports'

### DIFF
--- a/inc/customPostTypes/example.php
+++ b/inc/customPostTypes/example.php
@@ -43,7 +43,7 @@ namespace Flynt\CustomPostTypes;
 //         'label'                 => __('Post Type', 'flynt'),
 //         'description'           => __('Post Type Description', 'flynt'),
 //         'labels'                => $labels,
-//         'supports'              => ['title', 'editor'],
+//         'supports'              => ['title', 'editor', 'revisions'],
 //         'taxonomies'            => ['category', 'post_tag'],
 //         'hierarchical'          => false,
 //         'public'                => true,


### PR DESCRIPTION
Just a small thing - I used the example when I wanted to create a new post type and spotted that revisions are not there by default. I think having it enabled is a sensible default - better that you have this enabled and don't need it, rather than having it disabled when you later realise you need it and forgot.