### PR TITLE
BlockImageText: Style Update

### DIFF
--- a/Components/BlockImageText/_style.scss
+++ b/Components/BlockImageText/_style.scss
@@ -1,4 +1,8 @@
 [is='flynt-block-image-text'] {
+  .centerMaxWidthContainer {
+    max-width: 1200px;
+  }
+
   .box {
     @media (min-width: $breakpoint-tablet-horizontal) {
       align-items: center;
@@ -17,6 +21,14 @@
 
       &--imageRight {
         flex-direction: row-reverse;
+      }
+    }
+
+    @media (min-width: $breakpoint-desktop) {
+      margin: 0 -40px;
+
+      &-inner {
+        padding: 0 40px;
       }
     }
 

--- a/Components/BlockImageText/index.twig
+++ b/Components/BlockImageText/index.twig
@@ -1,6 +1,6 @@
 <div class="flyntComponent componentSpacing {{ options.theme }}" is="flynt-block-image-text">
   <div class="container centerMaxWidthContainer">
-    <div class="box box--{{ imagePosition }}">
+    <div class="box box--{{ imagePosition }} centerContentMaxWidth">
       <div class="box-inner box-inner--image">
         <figure class="figure">
           {% if image.post_mime_type == 'image/svg+xml' %}

--- a/Components/BlockImageText/index.twig
+++ b/Components/BlockImageText/index.twig
@@ -1,6 +1,6 @@
 <div class="flyntComponent componentSpacing {{ options.theme }}" is="flynt-block-image-text">
   <div class="container centerMaxWidthContainer">
-    <div class="box box--{{ imagePosition }} centerContentMaxWidth">
+    <div class="box box--{{ imagePosition }}">
       <div class="box-inner box-inner--image">
         <figure class="figure">
           {% if image.post_mime_type == 'image/svg+xml' %}


### PR DESCRIPTION
- max-width is the exception to the rule here. We could use something like $breakpoint-desktop (1280px) but this feels too big.
- Experimented with only increasing the padding _between_ the columns but this looks strange with normal images instead of illustrations. 