### PR TITLE
perf(inc/assets.php): don't load un-needed feather.js library

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -38,10 +38,4 @@ add_action('admin_enqueue_scripts', function () {
         'path' => 'assets/admin.css',
         'type' => 'style'
     ]);
-    Asset::enqueue([
-        'name' => 'Flynt/icons',
-        'type' => 'script',
-        'path' =>
-            'https://unpkg.com/feather-icons'
-    ]);
 });


### PR DESCRIPTION
We removed the select field with rendered icons so we don't need to load feather.js in the back-end anymore.