### PR TITLE
Grid image text optional image

### DIFF
--- a/Components/GridImageText/_style.scss
+++ b/Components/GridImageText/_style.scss
@@ -1,4 +1,3 @@
-
 [is='flynt-grid-image-text'] {
   .grid {
     @include reset-list;
@@ -19,14 +18,18 @@
     }
 
     &--length3 {
-      @media (min-width: $breakpoint-tablet-horizontal) {
-        flex-wrap: nowrap;
+      .grid-item {
+        @media (min-width: $breakpoint-tablet-horizontal) {
+          width: 33.33%;
+        }
       }
     }
 
     &--length4 {
-      @media (min-width: $breakpoint-desktop) {
-        flex-wrap: nowrap;
+      .grid-item {
+        @media (min-width: $breakpoint-desktop) {
+          width: 25%;
+        }
       }
     }
   }

--- a/Components/GridImageText/functions.php
+++ b/Components/GridImageText/functions.php
@@ -35,7 +35,6 @@ function getACFLayout()
                 'collapsed' => '',
                 'layout' => 'block',
                 'button_label' => 'Add',
-                'max' => 4,
                 'sub_fields' => [
                     [
                         'label' => 'Image',
@@ -79,6 +78,15 @@ function getACFLayout()
                 'layout' => 'row',
                 'sub_fields' => [
                     FieldVariables\getTheme(),
+                    [
+                        'label' => 'Columns',
+                        'name' => 'columns',
+                        'type' => 'number',
+                        'default_value' => 3,
+                        'min' => 1,
+                        'max' => 4,
+                        'step' => 1
+                    ],
                     [
                         'label' => 'Show as Card',
                         'name' => 'card',

--- a/Components/GridImageText/functions.php
+++ b/Components/GridImageText/functions.php
@@ -44,7 +44,7 @@ function getACFLayout()
                         'preview_size' => 'medium',
                         'instructions' => '',
                         'max_size' => 4,
-                        'required' => true,
+                        'required' => 0,
                         'mime_types' => 'gif,jpg,jpeg,png',
                         'wrapper' => [
                             'width' => 40
@@ -57,7 +57,7 @@ function getACFLayout()
                         'tabs' => 'visual,text',
                         'media_upload' => 0,
                         'delay' => 1,
-                        'required' => false,
+                        'required' => 0,
                         'wrapper' => [
                             'class' => 'autosize',
                             'width' => 60

--- a/Components/GridImageText/functions.php
+++ b/Components/GridImageText/functions.php
@@ -43,7 +43,6 @@ function getACFLayout()
                         'preview_size' => 'medium',
                         'instructions' => '',
                         'max_size' => 4,
-                        'required' => 0,
                         'mime_types' => 'gif,jpg,jpeg,png',
                         'wrapper' => [
                             'width' => 40
@@ -56,7 +55,6 @@ function getACFLayout()
                         'tabs' => 'visual,text',
                         'media_upload' => 0,
                         'delay' => 1,
-                        'required' => 0,
                         'wrapper' => [
                             'class' => 'autosize',
                             'width' => 60

--- a/Components/GridImageText/index.twig
+++ b/Components/GridImageText/index.twig
@@ -7,28 +7,32 @@
     {% endif %}
     <ul class="grid grid--length{{ items|length }}">
       {% for item in items %}
-        <li class="grid-item">
-          <div class="content {{ options.card == 'layoutCard' ? 'boxShadow themeReset' }}">
-            <img class="content-image lazyload"
-              src="{{ item.image.src|resizeDynamic(750, 500) }}"
-              srcset="{{ placeholderImage(3, 2) }}"
-              data-srcset="
-                {{ item.image.src|resizeDynamic(1920, 1280) }} 1920w,
-                {{ item.image.src|resizeDynamic(1280, 853) }} 1280w,
-                {{ item.image.src|resizeDynamic(1050, 700) }} 1050w,
-                {{ item.image.src|resizeDynamic(750, 500) }} 750w,
-                {{ item.image.src|resizeDynamic(600, 400) }} 600w,
-                {{ item.image.src|resizeDynamic(480, 320) }} 480w,
-                {{ item.image.src|resizeDynamic(312, 208) }} 312w"
-              data-sizes="auto"
-              alt="{{ item.image.alt|e }}">
-            {% if item.contentHtml %}
-              <div class="content-inner {{ options.card == 'layoutCard' ? 'boxPadding' }}">
-                {{ item.contentHtml|e('wp_kses_post') }}
-              </div>
-            {% endif %}
-          </div>
-        </li>
+        {% if item.image or item.contentHtml %}
+          <li class="grid-item">
+            <div class="content {{ options.card == 'layoutCard' ? 'boxShadow themeReset' }}">
+              {% if item.image %}
+                <img class="content-image lazyload"
+                  src="{{ item.image.src|resizeDynamic(750, 500) }}"
+                  srcset="{{ placeholderImage(3, 2) }}"
+                  data-srcset="
+                    {{ item.image.src|resizeDynamic(1920, 1280) }} 1920w,
+                    {{ item.image.src|resizeDynamic(1280, 853) }} 1280w,
+                    {{ item.image.src|resizeDynamic(1050, 700) }} 1050w,
+                    {{ item.image.src|resizeDynamic(750, 500) }} 750w,
+                    {{ item.image.src|resizeDynamic(600, 400) }} 600w,
+                    {{ item.image.src|resizeDynamic(480, 320) }} 480w,
+                    {{ item.image.src|resizeDynamic(312, 208) }} 312w"
+                  data-sizes="auto"
+                  alt="{{ item.image.alt|e }}">
+              {% endif %}
+              {% if item.contentHtml %}
+                <div class="content-inner {{ options.card == 'layoutCard' ? 'boxPadding' }}">
+                  {{ item.contentHtml|e('wp_kses_post') }}
+                </div>
+              {% endif %}
+            </div>
+          </li>
+        {% endif %}
       {% endfor %}
     </ul>
   </div>

--- a/Components/GridImageText/index.twig
+++ b/Components/GridImageText/index.twig
@@ -5,7 +5,7 @@
         {{ preContentHtml|e('wp_kses_post') }}
       </div>
     {% endif %}
-    <ul class="grid grid--length{{ items|length }}">
+    <ul class="grid grid--length{{ options.columns }}">
       {% for item in items %}
         {% if item.image or item.contentHtml %}
           <li class="grid-item">

--- a/Components/GridPostsLatest/_style.scss
+++ b/Components/GridPostsLatest/_style.scss
@@ -1,4 +1,3 @@
-
 [is='flynt-grid-posts-latest'] {
   .grid {
     @include reset-list;

--- a/Components/GridPostsLatest/functions.php
+++ b/Components/GridPostsLatest/functions.php
@@ -19,7 +19,7 @@ add_filter('Flynt/addComponentData?name=GridPostsLatest', function ($data) {
         'category' => join(',', array_map(function ($taxonomy) {
             return $taxonomy->term_id;
         }, $data['taxonomies'])),
-        'posts_per_page' => $data['options']['postCount'],
+        'posts_per_page' => $data['options']['columns'],
         'ignore_sticky_posts' => 1,
         'post__not_in' => array(get_the_ID())
     ]);
@@ -82,8 +82,8 @@ function getACFLayout()
                 'sub_fields' => [
                     FieldVariables\getTheme(),
                     [
-                        'label' => 'Post Count',
-                        'name' => 'postCount',
+                        'label' => 'Columns',
+                        'name' => 'columns',
                         'type' => 'number',
                         'default_value' => 3,
                         'min' => 1,

--- a/Components/GridPostsLatest/index.twig
+++ b/Components/GridPostsLatest/index.twig
@@ -6,7 +6,7 @@
           {{ preContentHtml|e('wp_kses_post') }}
         </div>
       {% endif %}
-      <ul class="grid grid--length{{ options.postCount }}">
+      <ul class="grid grid--length{{ options.columns }}">
         {% for item in items %}
           <li class="grid-item">
             <div class="content boxShadow themeReset">

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -15,7 +15,7 @@
         {{ renderComponent('BlockPostFooter', { post: post }) }}
       </section>
       <section class="post-related">
-        {{ renderComponent('GridPostsLatest', {'taxonomies': post.categories(), 'options': {'theme': 'themeLight', 'postCount': 3}}) }}
+        {{ renderComponent('GridPostsLatest', {'taxonomies': post.categories(), 'options': {'theme': 'themeLight', 'columns': 3}}) }}
       </section>
     </footer>
   </article>


### PR DESCRIPTION
- made image optional to allow text only boxes
- added columns option to control the width of an item
- removed the max item number
- changed variable name `itemCount` to `columns` in GridPostsLatest in favor of consistency