### PR TITLE
fix(theme): disable big image size threshold

### DIFF
--- a/inc/theme.php
+++ b/inc/theme.php
@@ -4,3 +4,5 @@ add_action('after_setup_theme', function () {
     add_theme_support('title-tag');
     add_theme_support('post-thumbnails');
 });
+
+add_filter('big_image_size_threshold', '__return_false');


### PR DESCRIPTION
this is a quick fix for the new image scaling functionality in wordpress 5.3.

this will make every image work that was uploaded after this fix is deployed. for images that where uploaded before and when on 5.3 we need a bigger fix.

should we go ahead and merge this and think about a more general way afterwards?