### PR TITLE
Link and Script type attributes

### DIFF
--- a/inc/cleanHead.php
+++ b/inc/cleanHead.php
@@ -56,18 +56,30 @@ add_action('init', function () {
 });
 
 /**
- * Remove id, class, type and media attributes from link tags.
+ * cleanStyleTag
+ *
+ * Clean up output of stylesheet <link> tags
  */
-\add_filter('style_loader_tag', function ($input) {
-    return \preg_replace(array( "#\s(id|class|type|media)='[^']+'#", '/\s{2,}/'), array('', ' '), $input);
+add_filter('style_loader_tag', function ($input) {
+    preg_match_all(
+        "!<link rel='stylesheet'\s?(id='[^']+')?\s+href='(.*)' type='text/css' media='(.*)' />!",
+        $input,
+        $matches
+    );
+    if (empty($matches[2])) {
+        return $input;
+    }
+    // Only display media if it is meaningful
+    $media = $matches[3][0] !== '' && $matches[3][0] !== 'all' ? ' media="' . $matches[3][0] . '"' : '';
+    return '<link rel="stylesheet" href="' . $matches[2][0] . '"' . $media . '>' . "\n";
 });
 
 /**
  * Remove type attribute from script tags if WordPress is lower than 5.3.
  */
 global $wp_version;
-if (\version_compare($wp_version, '5.3', '<')) {
-    \add_filter('script_loader_tag', function ($input) {
-        return \preg_replace(array("#\s(type)='[^']+'#", '/\s{2,}/'), array('', ' '), $input);
+if (version_compare($wp_version, '5.3', '<')) {
+    add_filter('script_loader_tag', function ($input) {
+        return preg_replace(["#\s(type)='[^']+'#", '/\s{2,}/'], ['', ' '], $input);
     });
 }

--- a/inc/cleanHead.php
+++ b/inc/cleanHead.php
@@ -56,18 +56,18 @@ add_action('init', function () {
 });
 
 /**
- * Remove id, class, type and media attributes from <link> tags.
+ * Remove id, class, type and media attributes from link tags.
  */
 \add_filter('style_loader_tag', function ($input) {
-    return \preg_replace( array( "#\s(id|class|type|media)='[^']+'#", '/\s{2,}/') , array('', ' ') , $input );
+    return \preg_replace(array( "#\s(id|class|type|media)='[^']+'#", '/\s{2,}/'), array('', ' '), $input);
 });
 
 /**
  * Remove type attribute from script tags if WordPress is lower than 5.3.
  */
 global $wp_version;
-if ( \version_compare($wp_version, '5.3', '<')) {
+if (\version_compare($wp_version, '5.3', '<')) {
     \add_filter('script_loader_tag', function ($input) {
-        return \preg_replace( array("#\s(type)='[^']+'#", '/\s{2,}/') , array('', ' ') , $input );
+        return \preg_replace(array("#\s(type)='[^']+'#", '/\s{2,}/'), array('', ' '), $input);
     });
 }

--- a/inc/cleanHead.php
+++ b/inc/cleanHead.php
@@ -56,15 +56,14 @@ add_action('init', function () {
 });
 
 /**
- * Remove id, class and media attributes from <link> tags.
- * Remove type attribute if WordPress is lower than 5.3.
+ * Remove id, class, type and media attributes from <link> tags.
  */
 \add_filter('style_loader_tag', function ($input) {
     return \preg_replace( array( "#\s(id|class|type|media)='[^']+'#", '/\s{2,}/') , array('', ' ') , $input );
 });
 
 /**
- * Remove type attribute from <script> tags if WordPress is lower than 5.3.
+ * Remove type attribute from script tags if WordPress is lower than 5.3.
  */
 global $wp_version;
 if ( \version_compare($wp_version, '5.3', '<')) {

--- a/inc/cleanHead.php
+++ b/inc/cleanHead.php
@@ -56,31 +56,19 @@ add_action('init', function () {
 });
 
 /**
- * cleanStyleTag
- *
- * Clean up output of stylesheet <link> tags
+ * Remove id, class and media attributes from <link> tags.
+ * Remove type attribute if WordPress is lower than 5.3.
  */
-add_filter('style_loader_tag', function ($input) {
-    preg_match_all(
-        "!<link rel='stylesheet'\s?(id='[^']+')?\s+href='(.*)' type='text/css' media='(.*)' />!",
-        $input,
-        $matches
-    );
-    if (empty($matches[2])) {
-        return $input;
-    }
-    // Only display media if it is meaningful
-    $media = $matches[3][0] !== '' && $matches[3][0] !== 'all' ? ' media="' . $matches[3][0] . '"' : '';
-    return '<link rel="stylesheet" href="' . $matches[2][0] . '"' . $media . '>' . "\n";
+\add_filter('style_loader_tag', function ($input) {
+    return \preg_replace( array( "#\s(id|class|type|media)='[^']+'#", '/\s{2,}/') , array('', ' ') , $input );
 });
 
 /**
- * cleanScriptTag
- *
- * Clean up output of <script> tags
- * TODO: fix or remove (broken on wp > 5.0.0)
+ * Remove type attribute from <script> tags if WordPress is lower than 5.3.
  */
-// add_filter('script_loader_tag', function ($input) {
-//     $input = str_replace("type='text/javascript' ", '', $input);
-//     return str_replace("'", '"', $input);
-// });
+global $wp_version;
+if ( \version_compare( $wp_version, '5.3', '<' ) ) {
+    \add_filter('script_loader_tag', function ($input) {
+        return \preg_replace( array( "#\s(type)='[^']+'#", '/\s{2,}/') , array('', ' ') , $input );
+    });
+}

--- a/inc/cleanHead.php
+++ b/inc/cleanHead.php
@@ -73,13 +73,3 @@ add_filter('style_loader_tag', function ($input) {
     $media = $matches[3][0] !== '' && $matches[3][0] !== 'all' ? ' media="' . $matches[3][0] . '"' : '';
     return '<link rel="stylesheet" href="' . $matches[2][0] . '"' . $media . '>' . "\n";
 });
-
-/**
- * Remove type attribute from script tags if WordPress is lower than 5.3.
- */
-global $wp_version;
-if (version_compare($wp_version, '5.3', '<')) {
-    add_filter('script_loader_tag', function ($input) {
-        return preg_replace(["#\s(type)='[^']+'#", '/\s{2,}/'], ['', ' '], $input);
-    });
-}

--- a/inc/cleanHead.php
+++ b/inc/cleanHead.php
@@ -67,8 +67,8 @@ add_action('init', function () {
  * Remove type attribute from <script> tags if WordPress is lower than 5.3.
  */
 global $wp_version;
-if ( \version_compare( $wp_version, '5.3', '<' ) ) {
+if ( \version_compare($wp_version, '5.3', '<')) {
     \add_filter('script_loader_tag', function ($input) {
-        return \preg_replace( array( "#\s(type)='[^']+'#", '/\s{2,}/') , array('', ' ') , $input );
+        return \preg_replace( array("#\s(type)='[^']+'#", '/\s{2,}/') , array('', ' ') , $input );
     });
 }

--- a/inc/theme.php
+++ b/inc/theme.php
@@ -8,7 +8,7 @@ add_action('after_setup_theme', function () {
      * Remove type attribute from link and script tags.
      */
     global $wp_version;
-    if ( version_compare( $wp_version, '5.3', '>=' ) ) {
+    if (version_compare($wp_version, '5.3', '>=')) {
         add_theme_support('html5', array('script', 'style'));
     }
 });

--- a/inc/theme.php
+++ b/inc/theme.php
@@ -5,7 +5,7 @@ add_action('after_setup_theme', function () {
     add_theme_support('post-thumbnails');
 
     /**
-     * Remove type attributes from link and script tags..
+     * Remove type attribute from link and script tags.
      */
     global $wp_version;
     if ( version_compare( $wp_version, '5.3', '>=' ) ) {

--- a/inc/theme.php
+++ b/inc/theme.php
@@ -3,6 +3,14 @@
 add_action('after_setup_theme', function () {
     add_theme_support('title-tag');
     add_theme_support('post-thumbnails');
+
+    /**
+     * Remove type attributes from link and script tags..
+     */
+    global $wp_version;
+    if ( version_compare( $wp_version, '5.3', '>=' ) ) {
+        add_theme_support('html5', array('script', 'style'));
+    }
 });
 
 add_filter('big_image_size_threshold', '__return_false');

--- a/inc/theme.php
+++ b/inc/theme.php
@@ -9,7 +9,7 @@ add_action('after_setup_theme', function () {
      */
     global $wp_version;
     if (version_compare($wp_version, '5.3', '>=')) {
-        add_theme_support('html5', array('script', 'style'));
+        add_theme_support('html5', ['script', 'style']);
     }
 });
 

--- a/inc/theme.php
+++ b/inc/theme.php
@@ -7,10 +7,7 @@ add_action('after_setup_theme', function () {
     /**
      * Remove type attribute from link and script tags.
      */
-    global $wp_version;
-    if (version_compare($wp_version, '5.3', '>=')) {
-        add_theme_support('html5', ['script', 'style']);
-    }
+    add_theme_support('html5', ['script', 'style']);
 });
 
 add_filter('big_image_size_threshold', '__return_false');


### PR DESCRIPTION
Theme.php
- Add theme support for Html5 style and script tags

CleanHead.php
- Remove id, class, type and media attributes from link tags.
- Remove type attribute from script tags if WordPress is lower than 5.3.
- Added \ to core and native functions to indicate the correct namespace.

Im not sure if these changes have to go to the flynt or flynt-starter-theme  repo!?
If it has to go into the flynt-starter-theme repo, let me know.