### PR TITLE
Add rules to .htaccess to restrict access to .twig files

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -30,3 +30,14 @@ add_action('after_setup_theme', function () {
      */
     load_theme_textdomain('flynt', get_template_directory() . '/languages');
 });
+
+
+// Add rules to .htaccess to restrict access to .twig files on theme setup.
+add_action('after_setup_theme', function () {
+    add_filter('mod_rewrite_rules', ['Flynt\Init', 'addTwigRestrictionRules']);
+});
+// Remove twig restriction rules from .htaccess on theme switch.
+add_action('switch_theme', function () {
+    remove_filter('mod_rewrite_rules', ['Flynt\Init', 'addTwigRestrictionRules']);
+    flush_rewrite_rules();
+});

--- a/lib/Init.php
+++ b/lib/Init.php
@@ -28,6 +28,26 @@ class Init
         do_action('Flynt/afterRegisterComponents');
     }
 
+    public static function addTwigRestrictionRules($rules)
+    {
+        $twig_rules = <<<EOD
+\n# BEGIN Twig Restriction
+<FilesMatch ".+\.twig$">
+\t<IfModule mod_authz_core.c>
+\t\t# Apache 2.4
+\t\tRequire all denied
+\t</IfModule>
+\t<IfModule !mod_authz_core.c>
+\t\t# Apache 2.2
+\t\tOrder deny,allow
+\t\tDeny from all
+\t</IfModule>
+</FilesMatch>
+# END Twig Restriction\n\n
+EOD;
+        return $twig_rules . $rules;
+    }
+
     public static function checkRequiredPlugins()
     {
         $acfActive = class_exists('acf');


### PR DESCRIPTION
Add access restriction rules to .htaccess for twig files on theme setup. Previously mentioned in #250.