### PR TITLE
feat(pageComponents): add page components to all pages and post types, but posts

### DIFF
--- a/inc/fieldGroups/pageComponents.php
+++ b/inc/fieldGroups/pageComponents.php
@@ -31,13 +31,8 @@ add_action('Flynt/afterRegisterComponents', function () {
             [
                 [
                     'param' => 'post_type',
-                    'operator' => '==',
-                    'value' => 'page'
-                ],
-                [
-                    'param' => 'page_type',
                     'operator' => '!=',
-                    'value' => 'posts_page'
+                    'value' => 'post'
                 ]
             ]
         ]

--- a/index.php
+++ b/index.php
@@ -1,12 +1,14 @@
 <?php
 
 use Timber\Timber;
+use Timber\Post;
 use Timber\PostQuery;
 use Flynt\Utils\Options;
 
 use const Flynt\Archives\POST_TYPES;
 
 $context = Timber::get_context();
+$context['post'] = new Post();
 $context['posts'] = new PostQuery();
 
 if (isset($_GET['contentOnly'])) {

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -2,4 +2,7 @@
 
 {% block content %}
   {{ renderComponent('GridPostsArchive', { posts: posts }) }}
+  {% for component in post.meta('pageComponents') %}
+    {{ renderComponent(component) }}
+  {% endfor %}
 {% endblock %}


### PR DESCRIPTION
When adding a new post type, it can be confusing that the backend interface is entirely empty by default. The page components should be added by default. 
Additionally, how the ACF location rule works is not obvious by looking at the code: top level evaluates to "OR", 2nd level to "AND". It's easy to make mistakes and getting stuck when trying to add the page components to a post type.
And lastly, I think it would be nice to have pageComponents optionally below the post on the posts archive page.

That's why I propose to add page components to all pages and post types, but posts.