### PR TITLE
Fix gulp revUpdateReferences on Windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ function revUpdateReferences (config) {
     const rewrite = require('gulp-rev-rewrite')
     var manifest = gulp.src(path.join(config.dest, 'rev-manifest.json'))
 
-    return gulp.src(path.join(config.dest, '/**/**.{css,js}'))
+    return gulp.src(config.rev.srcRevved)
       .pipe(rewrite({ manifest: manifest }))
       .pipe(gulp.dest(config.dest))
   })


### PR DESCRIPTION
Using the `path.join(config.dest, '/**/**.{css,js}')` on Windows a dist folder is created inside dist folder with all the updated references and the `dist/assets/*.{js,css}` files weren't updated with the references.