### PR TITLE
Timo hubois/navigation footer

### DIFF
--- a/Components/NavigationFooter/Partials/_menu.scss
+++ b/Components/NavigationFooter/Partials/_menu.scss
@@ -1,13 +1,24 @@
 .menu {
   display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
   justify-content: center;
   list-style: none;
   margin: 0;
   padding: 0;
 
+  @media (min-width: $breakpoint-mobile-horizontal) {
+    flex-direction: row;
+  }
+
   &-item {
     &:not(:first-child) {
-      margin-left: 2rem;
+      margin-top: 0.5rem;
+
+      @media (min-width: $breakpoint-mobile-horizontal) {
+        margin: 0;
+        margin-left: 2rem;
+      }
     }
   }
 

--- a/Components/NavigationFooter/functions.php
+++ b/Components/NavigationFooter/functions.php
@@ -3,8 +3,8 @@
 namespace Flynt\Components\NavigationFooter;
 
 use Flynt\Utils\Options;
-use Timber\Menu;
 use Flynt\Shortcodes;
+use Timber\Menu;
 
 add_action('init', function () {
     register_nav_menus([


### PR DESCRIPTION
refactor(NavigationBurger): use Timber\Menu sub-namespace instead of Timber
fix(NavigationFooter): fixed mobile menu styling