### PR TITLE
fix(webpackConfig): add content hash in chunked css file name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,7 +157,7 @@ const multiConfig = Object.keys(config.entry).map(entry => {
         // Options similar to the same options in webpackOptions.output
         // both options are optional
         filename: `${entry}.css`,
-        chunkFilename: `${entry}.css`
+        chunkFilename: `${entry}.[hash:8].css`
       })
     ]
   }


### PR DESCRIPTION
Required for dynamically importing CSS files.

Solves error: `Conflict: Multiple chunks emit assets to the same filename assets/main.css (chunks 2 and main)`.