### PR TITLE
Fix curly brace usage in string

### DIFF
--- a/lib/Utils/TwigExtensionRenderComponent.php
+++ b/lib/Utils/TwigExtensionRenderComponent.php
@@ -55,7 +55,7 @@ class TwigExtensionRenderComponent extends AbstractExtension
         $fn = function ($output, $componentName, $data) use ($env, $context, $withContext, $ignoreMissing, $sandboxed) {
             $componentManager = ComponentManager::getInstance();
             $templateFilename = apply_filters('Flynt/TimberLoader/templateFilename', 'index.twig');
-            $templateFilename = apply_filters("Flynt/TimberLoader/templateFilename?name=${componentName}", $templateFilename);
+            $templateFilename = apply_filters("Flynt/TimberLoader/templateFilename?name={$componentName}", $templateFilename);
             $filePath = $componentManager->getComponentFilePath($componentName, $templateFilename);
             $relativeFilePath = ltrim(str_replace(get_template_directory(), '', $filePath), '/');
 


### PR DESCRIPTION
If PHP it is `{$var}` not `${var}`.
