### PR TITLE
fix(FeatureFlexibleContentExtension): add component tooltip positioning

### DIFF
--- a/Components/FeatureFlexibleContentExtension/scripts/search.js
+++ b/Components/FeatureFlexibleContentExtension/scripts/search.js
@@ -26,7 +26,7 @@ if (window.acf) {
           const $target = $el[0]
           const targetTop = $target.getBoundingClientRect().bottom
           const targetHeight = $target.getBoundingClientRect().height
-          const offsetBottom = window.innerHeight + window.scrollY - targetTop + targetHeight + 10
+          const offsetBottom = window.innerHeight - window.scrollY - targetTop + targetHeight + 10
           $tooltip.style.top = 'auto'
           $tooltip.style.bottom = `${offsetBottom}px`
         }


### PR DESCRIPTION
Resolves issue mentioned here for me: https://github.com/flyntwp/flynt/discussions/499
Works locally in Firefox and Chrome.

Previously the tooltip could be positioned out of view when there's a scrollbar: 
<img width="1709" alt="Bildschirmfoto 2023-08-04 um 10 28 11" src="https://github.com/flyntwp/flynt/assets/5564163/6095f9f8-e5e8-4fab-9990-00b232b97103">

This is most likely my first direct code commit to an open source project through Github btw...hope everything  is fine in terms of the way how it's done 😉 Changing one character seems like a good start 😛