### PR TITLE
Fixing use of `execCommand('copy')`

### DIFF
--- a/Components/BlockAnchor/admin.js
+++ b/Components/BlockAnchor/admin.js
@@ -47,6 +47,13 @@
       const $copyMessage = $anchorField.find('.anchorLink-message')
 
       if (!navigator.clipboard) {
+        const selection = window.getSelection()
+        if (selection.rangeCount > 0) {
+          selection.removeAllRanges()
+        }
+        const range = document.createRange()
+        range.selectNode($anchorLinkInput.get(0))
+        selection.addRange(range)
         document.execCommand('copy')
       } else {
         navigator.clipboard.writeText($anchorLinkInput.text()).then(


### PR DESCRIPTION
When using the Copy Link button on the Anchor component without `navigator.clipboard` support, it reverts to `execCommand('copy')` which requires the content to copy to be selected.

This PR adds code to ensure the link is selected before calling `execCommand('copy')`.