### PR TITLE
fix(CleanHead): move emoji detection script removal from 'init' to 'admin_init'

### DIFF
--- a/inc/cleanHead.php
+++ b/inc/cleanHead.php
@@ -42,9 +42,7 @@ add_action('init', function (): void {
     remove_action('wp_head', 'wp_generator');
     remove_action('wp_head', 'wp_shortlink_wp_head', 10);
     remove_action('wp_head', 'print_emoji_detection_script', 7);
-    remove_action('admin_print_scripts', 'print_emoji_detection_script');
     remove_action('wp_print_styles', 'print_emoji_styles');
-    remove_action('admin_print_styles', 'print_emoji_styles');
     remove_action('wp_head', 'wp_oembed_add_discovery_links');
     remove_action('wp_head', 'wp_oembed_add_host_js');
     remove_action('wp_head', 'rest_output_link_wp_head', 10);
@@ -53,4 +51,9 @@ add_action('init', function (): void {
     remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
     add_filter('use_default_gallery_style', '__return_false');
     add_filter('emoji_svg_url', '__return_false');
+});
+
+add_action('admin_init', function (): void {
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('admin_print_styles', 'print_emoji_styles');
 });


### PR DESCRIPTION
If you use utf-8 emojis inside wp-admin, the `'print_emoji_detection_script'` script was still running, and the admin page loads were slowed down due to 404s from `cdn.jsdelivr.net`.

<img width="185" alt="Screenshot 2024-04-28 at 21 43 05" src="https://github.com/flyntwp/flynt/assets/5866973/71892470-0cc4-4a1a-8b37-b846560d30e7">

Moving the actions from `'init'` to `'admin_init'` fixes this.

<img width="224" alt="Screenshot 2024-04-28 at 21 56 00" src="https://github.com/flyntwp/flynt/assets/5866973/90f3fdd3-a76c-4331-b4e8-4e3d0e6e5c79">

