### PR TITLE
fix(_document.twig): accessibility fix: update skip link position

### DIFF
--- a/templates/_document.twig
+++ b/templates/_document.twig
@@ -8,12 +8,12 @@
   </head>
   <body>
     {{ function('wp_body_open') }}
-    <a href="#mainContent" class="visuallyHidden-focusable">
-      {{- theme.labels.skipToMainContent|e -}}
-    </a>
     {% block layout %}
       <div class="pageWrapper">
         <header class="mainHeader">
+          <a href="#mainContent" class="visuallyHidden-focusable">
+            {{- theme.labels.skipToMainContent|e -}}
+          </a>
           {% block header %}
             {{ renderComponent('NavigationMain') }}
             {{ renderComponent('NavigationBurger') }}


### PR DESCRIPTION
**Fix for accessibility issue:** 
All page content should be contained by landmarks 

**Why the Error Occurs:**
The "Skip to main content" link (`<a href="#mainContent">`) is not wrapped inside a landmark region (like `<header>`, `<nav>`, or a `<div>` with `role="banner"`). Since this link is outside any landmark, the axe rule region flags it as content not contained within a landmark.

Source: https://dequeuniversity.com/rules/axe/4.10/region?application=AxeChrome

**Merge readiness:** 
Ready to merge. This change doesn't effect anything visually. The element is visually hidden and also shows when is focused by keyboard. QA tested on flyntwp.com (see screenshots).

<img width="1440" alt="Screenshot 2025-06-02 at 15 59 15" src="https://github.com/user-attachments/assets/65aa2013-c9e5-4163-b23b-735b789c5b66" />
<img width="1440" alt="Screenshot 2025-06-02 at 15 59 34" src="https://github.com/user-attachments/assets/4287b86c-7cc3-4634-84b5-88cadb75eabb" /> 
