### PR TITLE
feat(assets): enqueue theme stylesheet

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -22,6 +22,7 @@ add_action('wp_enqueue_scripts', function (): void {
 
     wp_enqueue_style('Flynt/assets/main', Asset::requireUrl('assets/main.scss'), [], null);
     wp_enqueue_style('Flynt/assets/print', Asset::requireUrl('assets/print.scss'), [], null, 'print');
+    wp_enqueue_style('Flynt/assets/theme', Asset::requireUrl('assets/style.css'), [], null);
 });
 
 add_action('admin_enqueue_scripts', function (): void {


### PR DESCRIPTION
Previously, the main theme CSS was not enqueued by default, requiring manual inclusion via assets.php. I have now enabled default enqueuing for this file.
This allows for quick CSS overrides and emergency production fixes directly through the stylesheet, bypassing the need for a full theme rebuild when immediate changes are required.